### PR TITLE
Domain Create Components

### DIFF
--- a/codegen/ngc/src/domain_create/linked_domain_create.rs
+++ b/codegen/ngc/src/domain_create/linked_domain_create.rs
@@ -5,12 +5,23 @@ use crate::{has_attribute, remove_attribute};
 use log::info;
 use quote::format_ident;
 
-use syn::{Expr, FnArg, Ident, ImplItemMethod, Item, ItemFn, ItemTrait, Lit, Path, TraitItem, TraitItemMethod, parse_quote};
+use syn::{
+    parse_quote, Expr, FnArg, Ident, ImplItemMethod, Item, ItemFn, ItemTrait, Lit, Path, TraitItem,
+    TraitItemMethod,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub enum DomainCreateComponent {
+    Domain,
+    MMap,
+    Heap,
+}
 
 /// This generates a public fn and a impl method.
 /// This public fn is exposed to the kernel while the impl method is exposed to the users.
 pub fn generate_domain_create_for_trait_method(
     domain_path: &str,
+    domain_components: &Vec<DomainCreateComponent>,
     method: &TraitItemMethod,
 ) -> (syn::ImplItemMethod, syn::ItemFn) {
     // Remove `self` from the argument list
@@ -30,19 +41,73 @@ pub fn generate_domain_create_for_trait_method(
     let method_sig = &method.sig;
     let canonicalized_domain_path = domain_path.replace("/", "_");
     let generated_fn_ident = format_ident!("{}_{}", canonicalized_domain_path, method_ident);
-    let domain_start_ident = format_ident!("_binary_domains_build_{}_start", canonicalized_domain_path);
+    let domain_start_ident =
+        format_ident!("_binary_domains_build_{}_start", canonicalized_domain_path);
     let domain_end_ident = format_ident!("_binary_domains_build_{}_end", canonicalized_domain_path);
     let rtn = &method.sig.output;
     let ep_rtn = match &method.sig.output {
         syn::ReturnType::Type(_, ty) => match ty {
             box syn::Type::Tuple(tuple) => {
-                assert_eq!(tuple.elems.iter().count(), 2, "Expecting a tuple of two in the return type of method {:?} of domain {:?}", method_ident, domain_path);
+                assert_eq!(
+                    tuple.elems.iter().count(),
+                    2,
+                    "Expecting a tuple of two in the return type of method {:?} of domain {:?}",
+                    method_ident,
+                    domain_path
+                );
                 tuple.elems.iter().nth(1).unwrap()
-            },
-            _ => panic!("Expecting a tuple of two in the return type of method {:?} of domain {:?}", method_ident, domain_path),
+            }
+            _ => panic!(
+                "Expecting a tuple of two in the return type of method {:?} of domain {:?}",
+                method_ident, domain_path
+            ),
         },
-        syn::ReturnType::Default => panic!("Method {:?} of domain {:?} does not have a return type. Expecting a tuple of two.", method_ident, domain_path),
+        syn::ReturnType::Default => panic!(
+            "Method {:?} of domain {:?} does not have a return type. Expecting a tuple of two.",
+            method_ident, domain_path
+        ),
     };
+
+    info!("SELFLESS: {:#?}", selfless_args);
+
+    // Statements to initialize the components needed by the domain
+    let domain_component_creation = domain_components.iter().map(|component| {
+        match component {
+            &DomainCreateComponent::Domain => parse_quote! {
+                let pdom_ = ::alloc::boxed::Box::new(crate::syscalls::PDomain::new(::alloc::sync::Arc::clone(&dom_)));
+            },
+            &DomainCreateComponent::MMap => parse_quote! {
+                let pmmap_ = ::alloc::boxed::Box::new(crate::syscalls::Mmap::new());
+            },
+            &DomainCreateComponent::Heap => parse_quote! {
+                let pheap_ = ::alloc::boxed::Box::new(crate::heap::PHeap::new());
+            }
+        }
+    }).collect::<Vec<syn::Stmt>>();
+
+    info!("MADE IT!");
+
+    let domain_entrypoint_components: Vec<FnArg> = domain_components
+        .iter()
+        .map(|component| match component {
+            &DomainCreateComponent::Domain => parse_quote! {
+                pdom_: ::alloc::boxed::Box<dyn syscalls::Syscall>
+            },
+            &DomainCreateComponent::MMap => parse_quote! {
+                pmmap_: ::alloc::boxed::Box<dyn syscalls::Mmap>
+            },
+            &DomainCreateComponent::Heap => parse_quote! {
+                pheap_: ::alloc::boxed::Box<dyn syscalls::Heap>
+            },
+        })
+        .collect();
+
+    info!("MADE IT 2! {:#?}", domain_entrypoint_components);
+
+    let entry_point_args: Vec<&FnArg> = domain_entrypoint_components
+        .iter()
+        .chain(selfless_args.clone())
+        .collect();
 
     // Generate impl method.
     let generated_impl = parse_quote! {
@@ -60,10 +125,13 @@ pub fn generate_domain_create_for_trait_method(
         }
     };
 
-
     // Generated fn.
     let mut fn_sig = method_sig.clone();
     fn_sig.ident = generated_fn_ident.clone();
+
+    // The different domain_create_components required for starting the domain
+    // By default this is only ::syscalls:Syscall / PDomain and syscalls::Heap / PHeap
+
     let generated_fn = parse_quote! {
         pub(crate) fn #generated_fn_ident(#(#selfless_args),*) #rtn {
             // Entering kernel, disable irq
@@ -80,15 +148,15 @@ pub fn generate_domain_create_for_trait_method(
             );
 
             type UserInit_ =
-                fn(::alloc::boxed::Box<dyn ::syscalls::Syscall>, ::alloc::boxed::Box<dyn ::syscalls::Heap>, #(#selfless_args),*) -> #ep_rtn;
+                fn(#(#entry_point_args),*) -> #ep_rtn;
 
             let (dom_, entry_) = unsafe { crate::domain::load_domain(#domain_path, binary_range_) };
 
             // Type cast the pointer to entry point to the correct type.
             let user_ep_: UserInit_ = unsafe { ::core::mem::transmute::<*const (), UserInit_>(entry_) };
 
-            let pdom_ = ::alloc::boxed::Box::new(crate::syscalls::PDomain::new(::alloc::sync::Arc::clone(&dom_)));
-            let pheap_ = ::alloc::boxed::Box::new(crate::heap::PHeap::new());
+            // Creation of entry point arguments
+            #(#domain_component_creation)*
 
             // update current domain id.
             let thread_ = crate::thread::get_current_ref();
@@ -102,7 +170,7 @@ pub fn generate_domain_create_for_trait_method(
             // Enable interrupts on exit to user so it can be preempted.
             crate::interrupt::enable_irq();
             // Jumps to the domain entry point.
-            let ep_rtn_ = user_ep_(pdom_, pheap_, #(#selfless_args),*);
+            let ep_rtn_ = user_ep_(#(#entry_point_args),*);
             // Disable interrupts as we are back to the kernel.
             crate::interrupt::disable_irq();
 

--- a/codegen/ngc/src/domain_create/mod.rs
+++ b/codegen/ngc/src/domain_create/mod.rs
@@ -1,17 +1,20 @@
 mod blob_domain_create;
 mod linked_domain_create;
 
-use std::collections::HashMap;
-use crate::{has_attribute, remove_attribute};
+use crate::{
+    domain_create::linked_domain_create::DomainCreateComponent, has_attribute, remove_attribute,
+};
 use log::info;
 use quote::format_ident;
-use syn::{Expr, FnArg, Ident, ImplItemMethod, Item, ItemFn, ItemTrait, Lit, Path, TraitItem, TraitItemMethod, parse_quote};
-
-
+use std::{collections::HashMap, fmt::Result};
+use syn::{
+    parse_quote, Expr, FnArg, Ident, ImplItemMethod, Item, ItemFn, ItemTrait, Lit, Meta,
+    NestedMeta, Path, TraitItem, TraitItemMethod,
+};
 
 pub const LINKED_DOMAIN_CREATE_ATTR: &str = "domain_create";
 pub const BLOB_DOMAIN_CREATE_ATTR: &str = "domain_create_blob";
-
+pub const DOMAIN_CREATE_COMPONENTS_ATTR: &str = "domain_create_components";
 
 /// Generation of domain create.
 /// It also keep track of all the domain create it generates.
@@ -27,7 +30,11 @@ impl DomainCreateBuilder {
     }
 
     /// Generates the domain create for `input` if it has the `DOMAIN_CREATE_ATTR` attribute.
-    pub fn generate_domain_create(&mut self, input: &mut ItemTrait, module_path: &[Ident]) -> Option<Vec<Item>> {
+    pub fn generate_domain_create(
+        &mut self,
+        input: &mut ItemTrait,
+        module_path: &[Ident],
+    ) -> Option<Vec<Item>> {
         // Create an attribute map.
         let attrs: HashMap<String, Option<Lit>> = crate::utils::create_attribue_map(&input.attrs);
 
@@ -42,32 +49,83 @@ impl DomainCreateBuilder {
         } else {
             return None;
         }
-    
+
+        // Default domain create components, can be overridden with #[domain_create_components(Domain, MMap, Heap)]
+        let mut domain_components =
+            vec![DomainCreateComponent::Domain, DomainCreateComponent::Heap];
+
+        let metas = input.attrs.iter().map(|attr| attr.parse_meta().unwrap());
+        for meta in metas {
+            if meta.path().is_ident(DOMAIN_CREATE_COMPONENTS_ATTR) {
+                let mut new_domain_components = vec![];
+                // Override domain components
+                match meta {
+                    Meta::List(m) => {
+                        for component in m.nested.iter() {
+                            if let NestedMeta::Meta(comp) = component {
+                                if let Some(ident) = comp.path().get_ident() {
+                                    match ident.to_string().as_str() {
+                                        "Domain" => new_domain_components
+                                            .push(DomainCreateComponent::Domain),
+                                        "MMap" => {
+                                            new_domain_components.push(DomainCreateComponent::MMap)
+                                        }
+                                        "Heap" => {
+                                            new_domain_components.push(DomainCreateComponent::Heap)
+                                        }
+                                        other => {
+                                            panic!(
+                                                "Unsupported domain_create_component '{:#?}'",
+                                                &other
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                // info!("Domain Create Components: {:#?}", new_domain_components);
+                domain_components = new_domain_components;
+            }
+        }
+
+        remove_attribute!(input, DOMAIN_CREATE_COMPONENTS_ATTR);
+
         info!("Generating domain create for trait {:?}.", input.ident);
 
         // Compute the path to the trait.
-        let trait_path: String = module_path.iter().map(|ident| {
-            ident.to_string()
-        }).collect::<Vec<String>>().join("::");
+        let trait_path: String = module_path
+            .iter()
+            .map(|ident| ident.to_string())
+            .collect::<Vec<String>>()
+            .join("::");
         let trait_path = format!("{}::{}", trait_path, input.ident);
         let trait_path: syn::Path = syn::parse_str(&trait_path).unwrap();
 
         // Put the trait path into the list of domain creates.
-        self.domain_creates.push((trait_path.clone(), input.clone()));
+        self.domain_creates
+            .push((trait_path.clone(), input.clone()));
 
         // Create a copy of the input, refactor the path from `crate` to `interface, and we will be
         // working with the refactored one from now on.
         // The reason is that domain create will be generated into the kernel, which has a different
         // dependency path to the interface
         let mut input_copy = input.clone();
-        crate::path_refactoring::refactor_path_in_trait(&format_ident!("crate"), &format_ident!("interface"), &mut input_copy);
-    
+        crate::path_refactoring::refactor_path_in_trait(
+            &format_ident!("crate"),
+            &format_ident!("interface"),
+            &mut input_copy,
+        );
+
         // Add a comment so we know it's generated.
         input.attrs.push(
             parse_quote! {#[doc = "redIDL Auto Generated: domain_create trait. Generations are below"]},
         );
         let input = input_copy;
-    
+
         // Extract the domain path.
         let domain_path = crate::expect!(
             attrs.get("path"),
@@ -79,7 +137,7 @@ impl DomainCreateBuilder {
             Lit::Str(domain_path) => domain_path.value(),
             _ => panic!("Expecting a string."),
         };
-    
+
         // Generate code. Proxy is generated inplace and domain create is returned.
         let (generated_impl_items, generated_fns): (Vec<ImplItemMethod>, Vec<ItemFn>) = input
             .items
@@ -87,15 +145,22 @@ impl DomainCreateBuilder {
             .map(|item| match item {
                 TraitItem::Method(method) => {
                     if is_blob_domain_create {
-                        self::blob_domain_create::generate_domain_create_for_trait_method(&domain_path, method)
+                        self::blob_domain_create::generate_domain_create_for_trait_method(
+                            &domain_path,
+                            method,
+                        )
                     } else {
-                        self::linked_domain_create::generate_domain_create_for_trait_method(&domain_path, method)
+                        self::linked_domain_create::generate_domain_create_for_trait_method(
+                            &domain_path,
+                            &domain_components,
+                            method,
+                        )
                     }
                 }
                 _ => unimplemented!("Non-method member found in trait {:#?}", input),
             })
             .unzip();
-    
+
         // Generate the impl block.
         let mut generated: Vec<Item> = Vec::new();
         generated.push(Item::Impl(parse_quote! {
@@ -103,18 +168,17 @@ impl DomainCreateBuilder {
                 #(#generated_impl_items)*
             }
         }));
-    
+
         // Append the fn blocks
         generated.extend(generated_fns.into_iter().map(Item::Fn));
-    
+
         // Return the generated code.
         Some(generated)
     }
 
     pub fn generate_create_init(&self) -> Item {
-        let domain_create_paths: Vec<_> = self.domain_creates.iter().map(|(path, _)| {
-            path
-        }).collect();
+        let domain_create_paths: Vec<_> =
+            self.domain_creates.iter().map(|(path, _)| path).collect();
 
         let arcs: Vec<Expr> = self.domain_creates.iter().map(|_| {
             parse_quote! {
@@ -131,7 +195,7 @@ impl DomainCreateBuilder {
                     fn _binary_domains_build_redleaf_init_start();
                     fn _binary_domains_build_redleaf_init_end();
                 }
-            
+
                 let binary_range = (
                     _binary_domains_build_redleaf_init_start as *const u8,
                     _binary_domains_build_redleaf_init_end as *const u8,
@@ -144,11 +208,11 @@ impl DomainCreateBuilder {
 
                     #(::alloc::sync::Arc<dyn #domain_create_paths>,)*
                 );
-            
+
                 let (dom, entry) = unsafe { crate::domain::load_domain(name, binary_range) };
-            
+
                 let user_ep: UserInit = unsafe { ::core::mem::transmute::<*const (), UserInit>(entry) };
-            
+
                 // update current domain id
                 let thread = crate::thread::get_current_ref();
                 let old_id = {
@@ -157,7 +221,7 @@ impl DomainCreateBuilder {
                     thread.current_domain_id = dom.lock().id;
                     old_id
                 };
-            
+
                 // Enable interrupts on exit to user so it can be preempted
                 crate::interrupt::enable_irq();
                 user_ep(
@@ -167,12 +231,12 @@ impl DomainCreateBuilder {
                     #(#arcs),*
                 );
                 crate::interrupt::disable_irq();
-            
+
                 // change domain id back
                 {
                     thread.lock().current_domain_id = old_id;
                 }
-                
+
                 #[cfg(feature = "domain_create_log")]
                 println!("domain/{}: returned from entry point", name);
                 ::alloc::boxed::Box::new(crate::syscalls::PDomain::new(::alloc::sync::Arc::clone(&dom)))
@@ -184,4 +248,3 @@ impl DomainCreateBuilder {
         self.domain_creates
     }
 }
-


### PR DESCRIPTION
Essentially a fix for the PCI domain which requires a heap. Adds a new attribute that you can attach to domains to specify the components that should be passed to the domain's entry point.

```rust
#[domain_create(path = "pci")]
#[domain_create_components(Domain, MMap, Heap)] // <-- NEW!
pub trait CreatePCI: Send + Sync {
    fn create_domain_pci(&self) -> (Box<dyn Domain>, Box<dyn PCI>);
}
```